### PR TITLE
Add Homebrew workflow and curl-http3-libressl formula files

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,37 @@
+name: Homebrew Formula Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Update Homebrew
+        run: brew update
+
+      - name: Build and Install Formula
+        run: |
+          cd Formula
+          brew install -v --build-from-source ./curl-http3-libressl.rb
+
+      - name: Test Formula
+        run: |
+          cd Formula
+          brew test ./curl-http3-libressl.rb
+
+      - name: Cleanup Homebrew Cache
+        run: brew cleanup

--- a/Formula/curl-http3-libressl.rb
+++ b/Formula/curl-http3-libressl.rb
@@ -1,0 +1,90 @@
+# curl-http3-libressl.rb
+class CurlHttp3Libressl < Formula
+  desc "Get a file from an HTTP, HTTPS or FTP server"
+  homepage "https://curl.se"
+  url "https://curl.se/download/curl-8.10.1.tar.bz2"
+  sha256 "3763cd97aae41dcf41950d23e87ae23b2edb2ce3a5b0cf678af058c391b6ae31"
+  license "curl"
+
+  depends_on "pkg-config" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  resource "libressl" do
+    url "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.0.0.tar.gz"
+    sha256 "4d841955f0acc3dfc71d0e3dd35f283af461222350e26843fea9731c0246a1e4"
+  end
+
+  resource "nghttp3" do
+    url "https://github.com/ngtcp2/nghttp3.git",
+        using: :git,
+        tag: "v1.6.0",
+        revision: "e79890583f1ba8bb4d58d7456043a7e65205b34d"
+  end
+
+  resource "ngtcp2" do
+    url "https://github.com/ngtcp2/ngtcp2/archive/refs/tags/v1.8.1.tar.gz"
+    sha256 "99d6c0a589264096f088c0828919d0aeebcc8d0d3a03383632bd094ab24e687d"
+  end
+
+  def install
+    # Define paths for dependencies in the curl-specific directory under prefix
+    libressl_prefix = "#{prefix}/curl-http3-libressl/libressl"
+    nghttp3_prefix = "#{prefix}/curl-http3-libressl/nghttp3"
+    ngtcp2_prefix = "#{prefix}/curl-http3-libressl/ngtcp2"
+
+    # Build and install LibreSSL in the curl-specific directory
+    resource("libressl").stage do
+      system "./configure", "--prefix=#{libressl_prefix}", "--disable-shared", "--enable-static"
+      system "make"
+      system "make", "install"
+    end
+
+    # Build and install nghttp3 in the curl-specific directory
+    resource("nghttp3").stage do
+      system "git", "submodule", "update", "--init"
+      system "autoreconf -fi"
+      system "./configure", "--prefix=#{nghttp3_prefix}", "--enable-lib-only", "--disable-shared"
+      system "make"
+      system "make", "install"
+    end
+
+    # Build and install ngtcp2 in the curl-specific directory
+    resource("ngtcp2").stage do
+      system "autoreconf -fi"
+      system "./configure", "--prefix=#{ngtcp2_prefix}", "--enable-lib-only", "--disable-shared",
+                            "PKG_CONFIG_PATH=#{libressl_prefix}/lib/pkgconfig:#{nghttp3_prefix}/lib/pkgconfig"
+      system "make"
+      system "make", "install"
+    end
+
+    # Set PKG_CONFIG_PATH and LDFLAGS to reference curl-specific locations
+    ENV["PKG_CONFIG_PATH"] = "#{libressl_prefix}/lib/pkgconfig:#{nghttp3_prefix}/lib/pkgconfig:#{ngtcp2_prefix}/lib/pkgconfig"
+    ENV["LDFLAGS"] = "-Wl,-rpath,#{libressl_prefix}/lib -Wl,-rpath,#{nghttp3_prefix}/lib -Wl,-rpath,#{ngtcp2_prefix}/lib"
+
+    # Configure curl with static linking for dependencies
+    system "autoreconf", "-fi"
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-openssl=#{libressl_prefix}",
+                          "--with-nghttp3=#{nghttp3_prefix}",
+                          "--with-ngtcp2=#{ngtcp2_prefix}",
+                          "--enable-alt-svc",
+                          "--enable-http3",
+                          "--disable-shared",
+                          "--without-libpsl"
+    system "make"
+    system "make", "install"
+
+    # Update the paths to libraries in the curl binary using install_name_tool
+    system "install_name_tool", "-change", "#{libressl_prefix}/lib/libssl.58.dylib", "#{libressl_prefix}/lib/libssl.58.dylib", "#{bin}/curl"
+    system "install_name_tool", "-change", "#{libressl_prefix}/lib/libcrypto.55.dylib", "#{libressl_prefix}/lib/libcrypto.55.dylib", "#{bin}/curl"
+    system "install_name_tool", "-change", "#{nghttp3_prefix}/lib/libnghttp3.9.dylib", "#{nghttp3_prefix}/lib/libnghttp3.9.dylib", "#{bin}/curl"
+    system "install_name_tool", "-change", "#{ngtcp2_prefix}/lib/libngtcp2.16.dylib", "#{ngtcp2_prefix}/lib/libngtcp2.16.dylib", "#{bin}/curl"
+    system "install_name_tool", "-change", "#{ngtcp2_prefix}/lib/libngtcp2_crypto_quictls.2.dylib", "#{ngtcp2_prefix}/lib/libngtcp2_crypto_quictls.2.dylib", "#{bin}/curl"
+  end
+
+  test do
+    assert_match "nghttp3", shell_output("#{bin}/curl -V")
+  end
+end


### PR DESCRIPTION
This pull request introduces a new Homebrew formula for building and testing `curl` with HTTP/3 support using LibreSSL. The key changes include setting up a GitHub Actions workflow and defining the Homebrew formula.

### GitHub Actions Workflow:
* [`.github/workflows/homebrew-tap.yml`](diffhunk://#diff-acbea9d39f52208130c457c9e4dbabfec3f7456912ab792c5620463b810c2704R1-R36): Added a workflow to automate the testing of the Homebrew formula on pushes and pull requests to the main branch. This includes steps for checking out the repository, installing Homebrew, updating Homebrew, building and installing the formula, testing the formula, and cleaning up the Homebrew cache.

### Homebrew Formula Definition:
* [`Formula/curl-http3-libressl.rb`](diffhunk://#diff-0ee9c41ffe98c7e01552ae9c90d427cb1aab6c77d3d081b303007ae3ddfecaa6R1-R90): Created a new Homebrew formula for `curl` with HTTP/3 support. This includes specifying dependencies, defining resources for LibreSSL, nghttp3, and ngtcp2, and implementing the installation and testing procedures.