### PR TITLE
Add installation instructions for homebrew-tap in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # homebrew-tap
+
+```bash
+brew tap catatsuy/tap
+brew install curl-http3-libressl
+```


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds instructions for installing `curl-http3-libressl` using Homebrew.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R6): Added a code block with commands to tap the repository and install `curl-http3-libressl` using Homebrew.