### PR TITLE
Update curl and nghttp3/ngtcp2 versions in curl-http3-libressl.rb

### DIFF
--- a/Formula/curl-http3-libressl.rb
+++ b/Formula/curl-http3-libressl.rb
@@ -2,8 +2,8 @@
 class CurlHttp3Libressl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.se"
-  url "https://curl.se/download/curl-8.10.1.tar.bz2"
-  sha256 "3763cd97aae41dcf41950d23e87ae23b2edb2ce3a5b0cf678af058c391b6ae31" # curl sha256
+  url "https://curl.se/download/curl-8.12.1.tar.bz2"
+  sha256 "18681d84e2791183e0e5e4650ccb2a080c1f3a4e57ed2fbc2457228579d68269" # curl sha256
   license "curl"
 
   depends_on "pkg-config" => :build
@@ -19,13 +19,13 @@ class CurlHttp3Libressl < Formula
   resource "nghttp3" do
     url "https://github.com/ngtcp2/nghttp3.git",
         using: :git,
-        tag: "v1.6.0",
-        revision: "e79890583f1ba8bb4d58d7456043a7e65205b34d" # nghttp3 sha256
+        tag: "v1.8.0",
+        revision: "96ad17fd71d599b78a11e0ff635eccb7d2f6d649" # nghttp3 sha256
   end
 
   resource "ngtcp2" do
-    url "https://github.com/ngtcp2/ngtcp2/archive/refs/tags/v1.8.1.tar.gz"
-    sha256 "99d6c0a589264096f088c0828919d0aeebcc8d0d3a03383632bd094ab24e687d" # ngtcp2 sha256
+    url "https://github.com/ngtcp2/ngtcp2/archive/refs/tags/v1.11.0.tar.gz"
+    sha256 "144b169aa98ba2ca1f74cf40ff5e93b90a7bb1292f62b7998a8dd5c2a5eb102a" # ngtcp2 sha256
   end
 
   def install


### PR DESCRIPTION
This pull request updates the dependencies and resources for the `curl-http3-libressl` formula to their latest versions.

Dependency updates:

* Updated the `url` and `sha256` for `curl` to version 8.12.1.
* Updated the `tag` and `revision` for the `nghttp3` resource to version 1.8.0.
* Updated the `url` and `sha256` for the `ngtcp2` resource to version 1.11.0.