### PR TITLE
Add repository as a tap and update formula install/test commands

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -23,15 +23,17 @@ jobs:
       - name: Update Homebrew
         run: brew update
 
+      - name: Add this repository as a tap
+        run: |
+          brew tap catatsuy/tap .
+
       - name: Build and Install Formula
         run: |
-          cd Formula
-          brew install -v --build-from-source ./curl-http3-libressl.rb
+          brew install -v --build-from-source catatsuy/tap/curl-http3-libressl
 
       - name: Test Formula
         run: |
-          cd Formula
-          brew test ./curl-http3-libressl.rb
+          brew test catatsuy/tap/curl-http3-libressl
 
       - name: Cleanup Homebrew Cache
         run: brew cleanup


### PR DESCRIPTION
This pull request updates the Homebrew workflow to use the repository as a tap and simplifies the installation and testing steps for the `curl-http3-libressl` formula.

**Homebrew workflow improvements:**

* Added a step to tap the current repository using `brew tap catatsuy/tap .` to make the formula available as `catatsuy/tap/curl-http3-libressl`.
* Updated the build and install command to use the tapped formula path (`brew install -v --build-from-source catatsuy/tap/curl-http3-libressl`) instead of referencing the file directly.
* Updated the test command to use the tapped formula path (`brew test catatsuy/tap/curl-http3-libressl`) instead of referencing the file directly.