### PR TITLE
Fix brew tap developers mode

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -23,17 +23,15 @@ jobs:
       - name: Update Homebrew
         run: brew update
 
-      - name: Add this repository as a tap
-        run: |
-          brew tap catatsuy/tap .
-
       - name: Build and Install Formula
         run: |
-          brew install -v --build-from-source catatsuy/tap/curl-http3-libressl
+          cd Formula
+          brew install -v --build-from-source ./curl-http3-libressl.rb
 
       - name: Test Formula
         run: |
-          brew test catatsuy/tap/curl-http3-libressl
+          cd Formula
+          brew test ./curl-http3-libressl.rb
 
       - name: Cleanup Homebrew Cache
         run: brew cleanup

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -24,13 +24,11 @@ jobs:
         run: brew update
 
       - name: Build and Install Formula
+        env:
+          HOMEBREW_DEVELOPER: 1
         run: |
           cd Formula
           brew install -v --build-from-source ./curl-http3-libressl.rb
-
-      - name: Test Formula
-        run: |
-          cd Formula
           brew test ./curl-http3-libressl.rb
 
       - name: Cleanup Homebrew Cache


### PR DESCRIPTION
This pull request simplifies the Homebrew workflow by removing the use of a custom tap and updating how the formula is built and tested. The main changes focus on streamlining the installation and testing process for the `curl-http3-libressl` formula.

Homebrew workflow improvements:

* Removed the step that adds the repository as a tap, eliminating the need for `brew tap catatsuy/tap .` and making the workflow more straightforward.
* Updated the build and install step to set the `HOMEBREW_DEVELOPER` environment variable and directly install the formula from the `Formula` directory using `brew install -v --build-from-source ./curl-http3-libressl.rb`.
* Changed the test step to run `brew test ./curl-http3-libressl.rb` directly on the formula file, instead of referencing the tap.