### PR TITLE
add new formulas bento, notify-slack, purl and refactor CI workflow

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -9,27 +9,42 @@ on:
       - main
 
 jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      formula_files: ${{ steps.list.outputs.formula_files }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: List formula files
+        id: list
+        run: |
+          formula_files=$(find Formula -maxdepth 1 -name '*.rb' -print | sort | jq -Rsc 'split("\n") | map(select(length > 0))')
+          echo "formula_files=$formula_files" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: discover
     runs-on: macos-latest
+    env:
+      HOMEBREW_DEVELOPER: true
+    strategy:
+      fail-fast: false
+      matrix:
+        formula_file: ${{ fromJson(needs.discover.outputs.formula_files) }}
 
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
 
-      - name: Install Homebrew
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
       - name: Update Homebrew
         run: brew update
 
-      - name: Build and Install Formula
-        env:
-          HOMEBREW_DEVELOPER: 1
+      - name: Build and install formula
         run: |
-          cd Formula
-          brew install -v --build-from-source ./curl-http3-libressl.rb
-          brew test ./curl-http3-libressl.rb
+          formula_name="$(basename "${{ matrix.formula_file }}" .rb)"
+          brew install -v --build-from-source "./${{ matrix.formula_file }}"
+          brew test "$formula_name"
 
       - name: Cleanup Homebrew Cache
         run: brew cleanup

--- a/Formula/bento.rb
+++ b/Formula/bento.rb
@@ -1,0 +1,27 @@
+class Bento < Formula
+  desc "AI-assisted CLI for git workflows, translation, and repository dumps"
+  homepage "https://github.com/catatsuy/bento"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      # renovate: datasource=custom.bento-darwin-arm64 depName=catatsuy/bento asset=bento-darwin-arm64.tar.gz
+      url "https://github.com/catatsuy/bento/releases/download/v0.3.4/bento-darwin-arm64.tar.gz"
+      sha256 "7a920dda9e6c0e6e86ec6e4e27f17f0aa72fae0af008dc502f4c333844fff2ab"
+    end
+
+    on_intel do
+      # renovate: datasource=custom.bento-darwin-amd64 depName=catatsuy/bento asset=bento-darwin-amd64.tar.gz
+      url "https://github.com/catatsuy/bento/releases/download/v0.3.4/bento-darwin-amd64.tar.gz"
+      sha256 "d3fed5d46d4a4a652b9b602d8b6e9e8426f8ddffb7d83e0b89ce4bec3a9238d4"
+    end
+  end
+
+  def install
+    bin.install "bento"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bento -version 2>&1")
+  end
+end

--- a/Formula/notify-slack.rb
+++ b/Formula/notify-slack.rb
@@ -1,0 +1,27 @@
+class NotifySlack < Formula
+  desc "Post messages and snippets to Slack from the command line"
+  homepage "https://github.com/catatsuy/notify_slack"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      # renovate: datasource=custom.notify-slack-darwin-arm64 depName=catatsuy/notify_slack asset=notify_slack-darwin-arm64.tar.gz
+      url "https://github.com/catatsuy/notify_slack/releases/download/v0.5.9/notify_slack-darwin-arm64.tar.gz"
+      sha256 "c74b286474231e0b5cc66aa612d5e981f88c7e768e9a8cc7063270e0556ad144"
+    end
+
+    on_intel do
+      # renovate: datasource=custom.notify-slack-darwin-amd64 depName=catatsuy/notify_slack asset=notify_slack-darwin-amd64.tar.gz
+      url "https://github.com/catatsuy/notify_slack/releases/download/v0.5.9/notify_slack-darwin-amd64.tar.gz"
+      sha256 "0fbbf78b6fc4e4e3665e3169f29cc0e25ad0e773df832a81fff0e847cde5e206"
+    end
+  end
+
+  def install
+    bin.install "notify_slack"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/notify_slack -version 2>&1")
+  end
+end

--- a/Formula/purl.rb
+++ b/Formula/purl.rb
@@ -1,0 +1,27 @@
+class Purl < Formula
+  desc "Modern Perl-like text processing for files and standard input"
+  homepage "https://github.com/catatsuy/purl"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      # renovate: datasource=custom.purl-darwin-arm64 depName=catatsuy/purl asset=purl-darwin-arm64.tar.gz
+      url "https://github.com/catatsuy/purl/releases/download/v0.2.7/purl-darwin-arm64.tar.gz"
+      sha256 "3ba3fbcaee965701fcd49867feac0b943a16deeb6bfca06ef453267a1401e051"
+    end
+
+    on_intel do
+      # renovate: datasource=custom.purl-darwin-amd64 depName=catatsuy/purl asset=purl-darwin-amd64.tar.gz
+      url "https://github.com/catatsuy/purl/releases/download/v0.2.7/purl-darwin-amd64.tar.gz"
+      sha256 "7b93a49c49a727c3e70e51a0a8818b476bfe09a2bfd17b8f02e5b906f359e3b2"
+    end
+  end
+
+  def install
+    bin.install "purl"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/purl -version 2>&1")
+  end
+end


### PR DESCRIPTION
This pull request introduces three new Homebrew formulae for the `bento`, `notify_slack`, and `purl` CLI tools, and significantly refactors the Homebrew GitHub Actions workflow to support building and testing all formulae in the repository in a more scalable way. The workflow now dynamically discovers formula files and builds each one in parallel.

**Homebrew Formula Additions:**

* Added `Formula/bento.rb` to install the `bento` CLI tool for AI-assisted git workflows, with support for both ARM and Intel Macs.
* Added `Formula/notify-slack.rb` to install the `notify_slack` CLI tool for posting messages to Slack, with support for both ARM and Intel Macs.
* Added `Formula/purl.rb` to install the `purl` CLI tool for Perl-like text processing, with support for both ARM and Intel Macs.

**CI/CD Workflow Improvements:**

* Refactored `.github/workflows/homebrew-tap.yml` to:
  - Add a `discover` job that automatically finds all formula files in the `Formula` directory.
  - Update the `build` job to use a matrix strategy, building and testing each discovered formula file in parallel.
  - Remove hardcoded references to specific formulae, making the workflow scalable as new formulae are added.