### PR TITLE
remove brew audit step and update README with install and usage info

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -94,10 +94,6 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         run: brew update
 
-      - name: Audit formula
-        if: steps.diff.outputs.changed == 'true'
-        run: brew audit --strict "./Formula/${{ matrix.formula_name }}.rb"
-
       - name: Build and test formula
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # homebrew-tap
 
 ```bash
-brew tap catatsuy/tap
-brew install curl-http3-libressl
+brew install catatsuy/tap/bento
+brew install catatsuy/tap/notify-slack
+brew install catatsuy/tap/purl
+brew install catatsuy/tap/curl-http3-libressl
 ```
+
+Managed formula updates are applied with:
+
+```bash
+./scripts/update-formula.sh --all
+./scripts/update-formula.sh curl-http3-libressl
+```
+
+CI behavior:
+
+- `.github/workflows/homebrew-tap.yml` builds and tests every `Formula/*.rb`
+- `.github/workflows/update-formulas.yml` runs scheduled updates and opens one PR per managed formula when changes are detected


### PR DESCRIPTION
This pull request updates documentation to clarify installation and formula update procedures, and makes a minor change to the continuous integration workflow by removing a redundant audit step.

Documentation improvements:

* Updated `README.md` to list all available formulas for installation, added instructions for updating formulas using `./scripts/update-formula.sh`, and described the CI workflows for building, testing, and updating formulas.

Continuous integration workflow:

* Removed the `brew audit --strict` step from `.github/workflows/update-formulas.yml`, so the workflow now only builds and tests formulas when changes are detected.